### PR TITLE
fix version discrepency

### DIFF
--- a/committer.go
+++ b/committer.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-const VERSION = "0.1.4"
+const VERSION = "0.1.6"
 
 func main() {
 	version := flag.Bool("version", false, "Display version")

--- a/configure.sh
+++ b/configure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-VERSION="0.1.5"
+VERSION="0.1.6"
 GIT_PRE_COMMIT_HOOK=".git/hooks/pre-commit"
 COMMITTER_YML="committer.yml"
 COMMITTER_LOCATION="/usr/local/bin/committer"


### PR DESCRIPTION
discrepency between 1.4 and 1.5 which is calling a pull for committer every time someone tries to commit in zp and hi

https://gustohq.slack.com/archives/C6D142HL5/p1615565998038800