### PR TITLE
Add typescript to eslint commit hook

### DIFF
--- a/committer.yml
+++ b/committer.yml
@@ -7,7 +7,7 @@ tasks:
       output: '\[Corrected\]|=='
   - name: 'ESLint'
     command: yarn eslint --
-    files: '\.js|\.jsx'
+    files: '\.js|\.jsx|\.ts|\.tsx'
     fix:
       command: yarn eslint-fix-verbose -- --fix
       output: 'Generating fixed text for yarn'


### PR DESCRIPTION
We want to run eslint on Typescript files, too!

do I have to bump the version of this anywhere or something...?