### PR TITLE
Add ExcludeFilenames config

### DIFF
--- a/committer.go
+++ b/committer.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-const VERSION = "0.1.6"
+const VERSION = "0.1.7"
 
 func main() {
 	version := flag.Bool("version", false, "Display version")

--- a/configure.sh
+++ b/configure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-VERSION="0.1.6"
+VERSION="0.1.7"
 GIT_PRE_COMMIT_HOOK=".git/hooks/pre-commit"
 COMMITTER_YML="committer.yml"
 COMMITTER_LOCATION="/usr/local/bin/committer"

--- a/core/task.go
+++ b/core/task.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Task struct {
-	Name    string
-	Command string
-	Files   string
-	Fix     struct {
+	Name             string
+	Command          string
+	Files            string
+	ExcludeFilenames bool
+	Fix              struct {
 		Command   string
 		Output    string
 		Autostage bool
@@ -112,7 +113,7 @@ func (task Task) prepareCommand(fix bool) []string {
 
 	// Feed in changed files if we are running with --changed
 	relevantChangedFilesList := task.relevantChangedFiles(changedFilesList)
-	if len(relevantChangedFilesList) > 0 {
+	if !task.ExcludeFilenames && len(relevantChangedFilesList) > 0 {
 		cmdStr += " " + strings.Join(relevantChangedFilesList, " ")
 	}
 

--- a/core/task_test.go
+++ b/core/task_test.go
@@ -51,6 +51,24 @@ func TestPrepareCommand(t *testing.T) {
 	)
 }
 
+func TestPrepareCommandWithExcludeFilenames(t *testing.T) {
+	origChangedFiles := changedFilesList
+	changedFilesList = []string{"one.rb", "two.js", "three.txt"}
+	defer func() { changedFilesList = origChangedFiles }()
+
+	var task Task
+	task.Command = "run-task"
+	task.Files = ".txt"
+	task.ExcludeFilenames = true
+
+	assert.Equal(
+		t,
+		[]string{"run-task"},
+		task.prepareCommand(false),
+		"It correctly passes only the relevant files",
+	)
+}
+
 func TestPrepareFixedOutput(t *testing.T) {
 	var task Task
 	task.Fix.Output = "Fixed:"

--- a/core/task_test.go
+++ b/core/task_test.go
@@ -65,7 +65,7 @@ func TestPrepareCommandWithExcludeFilenames(t *testing.T) {
 		t,
 		[]string{"run-task"},
 		task.prepareCommand(false),
-		"It correctly passes only the relevant files",
+		"It correctly passes no file names",
 	)
 }
 


### PR DESCRIPTION
Some commands (e.g. sorbet) need to run without arguments. This allows a config to specify that.

I wanted to call this `PassFilenames` modeled off of https://pre-commit.com/#hooks-pass_filenames but went with `ExcludeFilenames` (even though it leads to a weird double-negative) because bools default to `false` and since the need for this config is rare I don't want to force people to set it.