### PR TITLE
Build and publish for linux platform

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -2,11 +2,19 @@
 
 set -xe
 
-export GOARCH="amd64"
+# Build for darwin
 export GOOS="darwin"
+
+export GOARCH="amd64"
 /usr/local/go/bin/go build -o committer.amd64 committer.go
 
 export GOARCH="arm64"
 /usr/local/go/bin/go build -o committer.arm64 committer.go
 
 /usr/bin/lipo committer.amd64 committer.arm64 -create -output committer
+
+# Also build for linux
+export GOOS="linux"
+
+export GOARCH="arm64"
+/usr/local/go/bin/go build -o committer.linux-arm64 committer.go

--- a/.github/build.sh
+++ b/.github/build.sh
@@ -6,12 +6,12 @@ set -xe
 export GOOS="darwin"
 
 export GOARCH="amd64"
-/usr/local/go/bin/go build -o committer.amd64 committer.go
+/usr/local/go/bin/go build -o committer.darwin-amd64 committer.go
 
 export GOARCH="arm64"
-/usr/local/go/bin/go build -o committer.arm64 committer.go
+/usr/local/go/bin/go build -o committer.darwin-arm64 committer.go
 
-/usr/bin/lipo committer.amd64 committer.arm64 -create -output committer
+/usr/bin/lipo committer.darwin-amd64 committer.darwin-arm64 -create -output committer
 
 # Also build for linux
 export GOOS="linux"

--- a/.github/build.sh
+++ b/.github/build.sh
@@ -16,5 +16,8 @@ export GOARCH="arm64"
 # Also build for linux
 export GOOS="linux"
 
+export GOARCH="amd64"
+/usr/local/go/bin/go build -o committer.linux-amd64 committer.go
+
 export GOARCH="arm64"
 /usr/local/go/bin/go build -o committer.linux-arm64 committer.go

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,8 +67,19 @@ jobs:
           asset_name: committer-${{ steps.vars.outputs.tag }}
           asset_content_type: application/octet-stream
 
-      - name: Upload Release Asset (Linux)
-        id: upload-release-asset-linux
+      - name: Upload Release Asset (Linux amd64)
+        id: upload-release-asset-linux-amd64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./committer.linux-amd64
+          asset_name: committer-${{ steps.vars.outputs.tag }}.linux-amd64
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset (Linux arm64)
+        id: upload-release-asset-linux-arm64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,8 +56,8 @@ jobs:
           draft: true
           prerelease: true
 
-      - name: Upload Release Asset
-        id: upload-release-asset
+      - name: Upload Release Asset (Darwin)
+        id: upload-release-asset-darwin
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,4 +65,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./committer
           asset_name: committer-${{ steps.vars.outputs.tag }}
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset (Linux)
+        id: upload-release-asset-linux
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./committer.linux-arm64
+          asset_name: committer-${{ steps.vars.outputs.tag }}.linux-arm64
           asset_content_type: application/octet-stream


### PR DESCRIPTION
Previously, only darwin builds of committer were being published. As we continue to work on containerized development, having linux builds for both amd64+arm64 are required.

## Testing
First I test built for linux arm64 locally:
```
committer on  main via  v1.19.1 on   (us-west-2)
❯ GOARCH="arm64" GOOS="linux" go build -o committer.linux-arm64 committer.go

```

Then I moved it inside of a containerized dev environment and confirmed it runs:
```
CloudDev(eh-an/support-docker-arm) ./ $ mv committer.linux-arm64 /usr/local/bin/committer
CloudDev(eh-an/support-docker-arm) ./ $ committer
Running commit hook for:
  ✅  - Codeowners

✅  Finished pre-commit hook
```