### PR TITLE
Update version to 0.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ committer --fix
 #### Release
 
 1. Make your changes on a branch.
-
-2. Once landed in origin/main, add a new version tag to the branch:
+2. Update `VERSION` in `committer.go` to new version number.
+3. Once landed in origin/main, add a new version tag to the branch:
 ```shell
 git fetch && git checkout main && git pull
 git tag --annotate "vNEW.VERSION.HERE"
 git push --follow-tags
 ```
-3. `.github/workflows/publish.yml` will generate a new release for your tag. Follow the action in said tab.
+4. `.github/workflows/publish.yml` will generate a new release for your tag. Follow the action in said tab.
 
-4. The `v` is important.
+5. The `v` is important.
 
 #### Deploy
 

--- a/committer.go
+++ b/committer.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-const VERSION = "0.1.10"
+const VERSION = "0.1.12"
 
 func main() {
 	version := flag.Bool("version", false, "Display version")


### PR DESCRIPTION
When releasing 0.1.11, I didn't bump the version number within `committer.go` causing the publish [to fail](https://github.com/Gusto/committer/actions/runs/3193330008/jobs/5211781443) 🤦 

```
Run /bin/chmod +x ./committer
  /bin/chmod +x ./committer
  [[ "$(./committer --version)" == "$(echo 'v0.1.11' | /usr/bin/sed s/v//g)" ]]
  shell: /bin/bash -e {0}
Error: Process completed with exit code 1.
```

This updates the release instructions to mention the version bump, in addition to bumping the version to 0.1.12.